### PR TITLE
Crypto.Modes breaks intel-aes

### DIFF
--- a/Codec/Crypto/GladmanAES.hsc
+++ b/Codec/Crypto/GladmanAES.hsc
@@ -10,7 +10,7 @@ module Codec.Crypto.GladmanAES
 	( AES
 	, N128, N192, N256
 	, module Crypto.Classes
-	, module Crypto.Modes) where
+        ) where
 
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Internal as BI


### PR DESCRIPTION
I've been reworking how modes are exported for block ciphers in crypto-api.  As a result, Crypto.Modes could probably use rethought.  At the very least, exporting Modes and Classes at the same time is not advisable (name conflicts).
